### PR TITLE
Fixing Comparison of cbTargetBPFStages Checkbox.SelectedItem with == ""

### DIFF
--- a/BPFManager/BPFManager.cs
+++ b/BPFManager/BPFManager.cs
@@ -387,9 +387,6 @@ namespace Carfup.XTBPlugins.BPFManager
             List<string> traversedpath = new List<string>();
             string targetStage = cbTargetBPFStages.SelectedItem.ToString();
             var totalRecordMigrated = 0;
-            var totalRecordInstanced = 0;
-            var totalRecordUpdated = 0;
-            var totalSkipped = 0;
             totalRecordToMigrate = recordToMigrateList.Count;
             migrationErrors = new List<MigrationError>();
 
@@ -433,7 +430,6 @@ namespace Carfup.XTBPlugins.BPFManager
                     // Get lookup field between record entity & bpf entity
                     var referencingAttributeEntityBpf = this.dm.RetrieveReferencingAttributeOfBpf(bpfSelectedEntityName, recordEntityToMigrate);
 
-                    var recordInstanced = 0;
                     var numberOfRecordsToProceed = recordToMigrateList.Count;
 
                     var executeMultipleRequestSetBPF = new ExecuteMultipleRequest()

--- a/BPFManager/BPFManager.cs
+++ b/BPFManager/BPFManager.cs
@@ -362,13 +362,13 @@ namespace Carfup.XTBPlugins.BPFManager
                 return false;
             }
 
-            if (cbTargetBPFStages.SelectedItem == "" || cbTargetBPFStages.SelectedItem == null)
+            if (cbTargetBPFStages.SelectedItem == null || cbTargetBPFStages.GetItemText(cbTargetBPFStages.SelectedItem) == "")
             {
                 MessageBox.Show("You need to select a target Business process flow first.");
                 return false;
             }
 
-            if (cbTargetBPFList.SelectedItem == "" || cbTargetBPFList.SelectedItem == null)
+            if (cbTargetBPFList.SelectedItem == null || cbTargetBPFStages.GetItemText(cbTargetBPFList.SelectedItem) == "")
             {
                 MessageBox.Show("You need to select a target Business process flow Stage first.");
                 return false;


### PR DESCRIPTION
Hi Clement,

Visual Studio alerted me to this potential bug. Previously you were [comparing by reference](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0252?f1url=%3FappId%3Droslyn%26k%3Dk(CS0252)).

P.S: I also removed some unused variables inside the btnMigrateRecordBPF_Click while I was at it.